### PR TITLE
Create Dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "maven" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
As requested by @johankumps, here is the (basic) configuration file for [Dependabot](https://docs.github.com/en/code-security/dependabot).

As soon as this is merged, Dependabot will check all the dependencies listed in `pom.xml` (every week - can be configured) and create a PR to upgrade those dependencies. This will also create PR for security patches immediately.

Since we already used KE in our code base, here is a non-exhaustive list of the dependencies upgrade that will come:
- openapi-generator-maven-plugin
- jetty-server
- jackson-version