### PR TITLE
Simplify process of making releases

### DIFF
--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build JARs
-        run: mvn $MAVEN_CLI_OPTS package
+        run: mvn -Dmaven.test.skip=true package
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -3,11 +3,12 @@ name: Release Docker images
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.prerelease == false
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && github.event.prerelease == false)
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -1,0 +1,47 @@
+name: Release Docker images
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.prerelease == false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Build JARs
+        run: mvn $MAVEN_CLI_OPTS package
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push Knowledge Directory Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./knowledge-directory
+          platforms: linux/amd64, linux/arm64
+          tags: ghcr.io/tno/knowledge-engine/knowledge-directory:${{ github.event.release.tag_name }}
+          push: true
+      - name: Build and push Smart Connector Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./smart-connector-rest-dist
+          platforms: linux/amd64, linux/arm64
+          tags: ghcr.io/tno/knowledge-engine/smart-connector:${{ github.event.release.tag_name }}
+          push: true
+      - name: Build and push Admin UI Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./admin-ui
+          platforms: linux/amd64, linux/arm64
+          tags: ghcr.io/tno/knowledge-engine/admin-ui:${{ github.event.release.tag_name }}
+          push: true

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -9,7 +9,7 @@ on:
         type: string
 
 env:
-  MAVEN_OPTS: -Dhttps.protocols=TLSv1.2 -Dmaven.repo.local=$CI_PROJECT_DIR/.m2/repository -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true
+  MAVEN_OPTS: -Dmaven.test.skip=true -Dhttps.protocols=TLSv1.2 -Dmaven.repo.local=$CI_PROJECT_DIR/.m2/repository -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true
   MAVEN_CLI_OPTS: --batch-mode --errors --fail-at-end --show-version
 
 jobs:

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,41 @@
+name: Make draft release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version for new release (X.Y.Z)"
+        required: true
+        type: string
+
+env:
+  MAVEN_OPTS: -Dhttps.protocols=TLSv1.2 -Dmaven.repo.local=$CI_PROJECT_DIR/.m2/repository -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true
+  MAVEN_CLI_OPTS: --batch-mode --errors --fail-at-end --show-version
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    container:
+      image: maven:3.9.9-eclipse-temurin-17-focal
+      options: --user 1001
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build JARs
+        run: mvn $MAVEN_CLI_OPTS package
+      - name: Create tag
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git tag -a ${{ inputs.version }} -m ${{ inputs.version }}
+          git push origin ${{ inputs.version }}
+      - name: Draft release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            smart-connector-rest-dist-${{ inputs.version }}-with-dependencies.jar
+            knowledge-directory-${{ inputs.version }}-with-dependencies.jar
+          tag_name: ${{ inputs.version }}
+          draft: true
+          generate_release_notes: true
+          make_latest: true

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -32,9 +32,10 @@ jobs:
       - name: Draft release
         uses: softprops/action-gh-release@v2
         with:
+          working-directory: ${{ github.workspace }}
           files: |
-            smart-connector-rest-dist-${{ inputs.version }}-with-dependencies.jar
-            knowledge-directory-${{ inputs.version }}-with-dependencies.jar
+            smart-connector-rest-dist/target/smart-connector-rest-dist-${{ inputs.version }}-with-dependencies.jar
+            knowledge-directory/target/knowledge-directory-${{ inputs.version }}-with-dependencies.jar
           tag_name: ${{ inputs.version }}
           draft: true
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -204,14 +204,15 @@ These are instructions on what to do when we release a new version of the knowle
 	- all `pom.xml` files
 	- `openapi-sc.yaml` version
 	- Docker image tags in the Docker Compose examples.
-2. Make a commit for the release in a PR and merge it into master
-3. Go to Actions on GitHub and trigger the workflow "Make draft release" with the new version as input.
-4. When the workflow is finished, go to the newly generated draft release. Check the release notes, make any changes if necessary, and publish the release.
-5. Prepare the next SNAPSHOT version and make a commit for that in a PR and merge into master.
+2. Make a commit and push it to a new branch for the release.
+3. Make a Pull Request and merge it into master after tests have succeeded.
+4. Go to Actions on GitHub and trigger the workflow "Make draft release" with the new version as input.
+5. When the workflow is finished, go to the newly generated draft release. Check the release notes, make any changes if necessary, and publish the release.
+6. Prepare the next SNAPSHOT version and make a commit for that in a PR and merge into master.
    1. `openapi-sc.yaml`
    2. `pom.xml`
    3. Leave the non-SNAPSHOT version in this README, and in the Docker Compose examples.
-6. Inform mailing list(s) (and [the blog](https://www.knowledge-engine.eu/blog/)) about the new release.
+7. Inform mailing list(s) (and [the blog](https://www.knowledge-engine.eu/blog/)) about the new release.
 
 ## Code conventions
 The code conventions of the knowledge-engine can be found in the `/ide` folder in the Eclipse IDE format. The format can often also be imported in other Java IDEs like IntelliJ, VSCode or Netbeans.

--- a/README.md
+++ b/README.md
@@ -204,37 +204,14 @@ These are instructions on what to do when we release a new version of the knowle
 	- all `pom.xml` files
 	- `openapi-sc.yaml` version
 	- Docker image tags in the Docker Compose examples.
-2. Make a commit for the release, and tag it with `git tag {x}.{y}.{z}`.
-3. `mvn deploy` (for this you need `Deploy-Token` or `Private-Token` configured in your Maven's `settings.xml`, see [GitLab's documentation on this](https://docs.gitlab.com/ee/user/packages/maven_repository/#authenticate-to-the-package-registry-with-maven))
-4. Push the commit and the tag.
-5. Build and push the new Docker images to GitLab:
-
-```bash
-docker buildx build ./smart-connector-rest-dist --platform linux/arm64,linux/amd64 --tag docker-registry.inesctec.pt/interconnect/knowledge-engine/smart-connector-rest-dist:1.2.5 --push
-docker buildx build ./knowledge-directory --platform linux/arm64,linux/amd64 --tag docker-registry.inesctec.pt/interconnect/knowledge-engine/knowledge-directory:1.2.5 --push
-docker buildx build ./admin-ui --platform linux/arm64,linux/amd64 --tag docker-registry.inesctec.pt/interconnect/knowledge-engine/admin-ui:1.2.5 --push
-```
-
-6. Build and push the new Docker images to GitHub:
-
-```bash
-docker buildx build ./smart-connector-rest-dist --platform linux/arm64,linux/amd64 --tag ghcr.io/tno/knowledge-engine/smart-connector:1.2.5 --push
-docker buildx build ./knowledge-directory --platform linux/arm64,linux/amd64 --tag ghcr.io/tno/knowledge-engine/knowledge-directory:1.2.5 --push
-docker buildx build ./admin-ui --platform linux/arm64,linux/amd64 --tag ghcr.io/tno/knowledge-engine/admin-ui:1.2.5 --push
-```
-
-7. Prepare the next SNAPSHOT version and make a commit for that too.
+2. Make a commit for the release in a PR and merge it into master
+3. Go to Actions on GitHub and trigger the workflow "Make draft release" with the new version as input.
+4. When the workflow is finished, go to the newly generated draft release. Check the release notes, make any changes if necessary, and publish the release.
+5. Prepare the next SNAPSHOT version and make a commit for that in a PR and merge into master.
    1. `openapi-sc.yaml`
    2. `pom.xml`
    3. Leave the non-SNAPSHOT version in this README, and in the Docker Compose examples.
-8. In GitLab, create a new release at https://gitlab.inesctec.pt/interconnect/knowledge-engine/-/releases
-   1. Use the new tag for the release
-   2. Write release notes
-   3. Find the latest version of the package at https://gitlab.inesctec.pt/interconnect/knowledge-engine/-/packages/976 and copy the link to the JAR with dependencies. Include it in "Release assets" with type "Package" and link title "Knowledge Engine REST server JAR (with dependencies)" (see previous releases)
-9. In GitHub, create a new release at https://github.com/TNO/knowledge-engine/releases/new
-   1. Use the new tag for the release
-   2. Include the same release notes
-10. Inform mailing list(s) (and [the blog](https://www.knowledge-engine.eu/blog/)) about the new release.
+6. Inform mailing list(s) (and [the blog](https://www.knowledge-engine.eu/blog/)) about the new release.
 
 ## Code conventions
 The code conventions of the knowledge-engine can be found in the `/ide` folder in the Eclipse IDE format. The format can often also be imported in other Java IDEs like IntelliJ, VSCode or Netbeans.


### PR DESCRIPTION
This PR adds a Github workflow for (1) drafting a release, and (2) uploading Docker images to the registry.

This will modify the way that we're currently making releases. I envision the following workflow: 
1. User makes commit to prepare for the version release, changing the versions where needed (same as current first step)
2. User triggers Github Action via Github's interface, you will be asked to provide the new version (X.Y.Z) as input
3. Draft release is made by workflow (1)
4. When ready, user inspects the draft release made by the workflow. The user can make changes if necessary and 'publishes' it definitively
5. Docker images are made and uploaded by workflow (2)
6. User makes commit for next SNAPSHOT version (the same as current 7th step)
7. Inform the world

Fixes #490 