### PR TITLE
Fixed some javadoc errors.

### DIFF
--- a/smart-connector-api/src/main/java/eu/knowledge/engine/smartconnector/api/AnswerKnowledgeInteraction.java
+++ b/smart-connector-api/src/main/java/eu/knowledge/engine/smartconnector/api/AnswerKnowledgeInteraction.java
@@ -6,7 +6,7 @@ package eu.knowledge.engine.smartconnector.api;
  * {@code pattern}.
  *
  * In other words, the {@link KnowledgeBase} can answer those kinds of questions
- * for its {@link SmartConnectorImpl}.
+ * for its {@link SmartConnector}.
  */
 public final class AnswerKnowledgeInteraction extends KnowledgeInteraction {
 
@@ -35,7 +35,7 @@ public final class AnswerKnowledgeInteraction extends KnowledgeInteraction {
 
 	/**
 	 * Create an {@link AnswerKnowledgeInteraction}. See
-	 * {@link KnowledgeInteraction#KnowledgeInteraction(CommunicativeAct, String, boolean, boolean, MatchStrategy)
+	 * {@link KnowledgeInteraction#KnowledgeInteraction(CommunicativeAct, String, boolean, boolean, boolean, MatchStrategy)}
 	 *
 	 * @param aPattern The {@link GraphPattern} expresses the 'shape' of knowledge
 	 *                 that this {@link KnowledgeInteraction} can provide.

--- a/smart-connector-api/src/main/java/eu/knowledge/engine/smartconnector/api/AskKnowledgeInteraction.java
+++ b/smart-connector-api/src/main/java/eu/knowledge/engine/smartconnector/api/AskKnowledgeInteraction.java
@@ -6,7 +6,7 @@ package eu.knowledge.engine.smartconnector.api;
  * {@code pattern}.
  *
  * In other words, the {@link KnowledgeBase} asks these kinds of questions to
- * its {@link SmartConnectorImpl}.
+ * its {@link SmartConnector}.
  */
 public final class AskKnowledgeInteraction extends KnowledgeInteraction {
 
@@ -36,7 +36,7 @@ public final class AskKnowledgeInteraction extends KnowledgeInteraction {
 
 	/**
 	 * Create a {@link AskKnowledgeInteraction}. See
-	 * {@link KnowledgeInteraction#KnowledgeInteraction(CommunicativeAct, String, boolean, boolean, MatchStrategy)
+	 * {@link KnowledgeInteraction#KnowledgeInteraction(CommunicativeAct, String, boolean, boolean, boolean, MatchStrategy)}.
 	 *
 	 * @param pattern The {@link GraphPattern} expresses the 'shape' of knowledge
 	 *                that this {@link KnowledgeInteraction} asks for.

--- a/smart-connector-api/src/main/java/eu/knowledge/engine/smartconnector/api/GraphPattern.java
+++ b/smart-connector-api/src/main/java/eu/knowledge/engine/smartconnector/api/GraphPattern.java
@@ -23,9 +23,8 @@ import eu.knowledge.engine.smartconnector.util.GraphPatternSerialization;
 
 /**
  * A {@link GraphPattern} expresses a 'shape' of knowledge. We use Basic Graph
- * Pattern syntax from SPARQL 1.1
- * {@linkplain https://www.w3.org/TR/sparql11-query/} to represent this
- * knowledge.
+ * Pattern syntax from <a href="https://www.w3.org/TR/sparql11-query/">SPARQL
+ * 1.1</a> to represent this knowledge.
  *
  * It is a conjunction of triple patterns, where each triple pattern consists of
  * a {@code subject}, {@code predicate} and {@code object}. Each of these can be

--- a/smart-connector-api/src/main/java/eu/knowledge/engine/smartconnector/api/KnowledgeGap.java
+++ b/smart-connector-api/src/main/java/eu/knowledge/engine/smartconnector/api/KnowledgeGap.java
@@ -10,7 +10,7 @@ import eu.knowledge.engine.reasoner.api.TriplePattern;
  * to be present in order to satisfy an ask/post interaction.
  *
  * Note that there can be multiple knowledge gaps in an ask or post interaction.
- * They will be combined in a Set<KnowledgeGap>s that contains one or more
+ * They will be combined in a {@code Set<KnowledgeGap>}s that contains one or more
  * {@link KnowledgeGap}s in an <i><b>OR</b></i> fashion.
  *
  *  */

--- a/smart-connector-api/src/main/java/eu/knowledge/engine/smartconnector/api/KnowledgeInteraction.java
+++ b/smart-connector-api/src/main/java/eu/knowledge/engine/smartconnector/api/KnowledgeInteraction.java
@@ -2,10 +2,10 @@ package eu.knowledge.engine.smartconnector.api;
 
 /**
  * A {@link KnowledgeInteraction} represents an agreement about the exchange of
- * knowledge between the {@link SmartConnectorImpl} and the
+ * knowledge between the {@link SmartConnector} and the
  * {@link KnowledgeBase}. It expresses the 'shape' of knowledge that a
  * {@link KnowledgeBase} asks from, or can provide to its
- * {@link SmartConnectorImpl}.
+ * {@link SmartConnector}.
  */
 public abstract class KnowledgeInteraction {
 

--- a/smart-connector-api/src/main/java/eu/knowledge/engine/smartconnector/api/ReactHandler.java
+++ b/smart-connector-api/src/main/java/eu/knowledge/engine/smartconnector/api/ReactHandler.java
@@ -4,7 +4,7 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * A {@link ReactHandler} provides a handler method
- * ({@link ReactHandler#react(ReactKnowledgeInteraction, BindingSet)}) that
+ * ({@link ReactHandler#react(ReactKnowledgeInteraction, ReactExchangeInfo)}) that
  * returns a {@link BindingSet} for the provided input. Unlike in the
  * {@link AnswerHandler}, which only has a single {@link GraphPattern}, the
  * {@link GraphPattern} of the result *can* be different from the argument's.

--- a/smart-connector-api/src/main/java/eu/knowledge/engine/smartconnector/api/SmartConnector.java
+++ b/smart-connector-api/src/main/java/eu/knowledge/engine/smartconnector/api/SmartConnector.java
@@ -10,39 +10,38 @@ public interface SmartConnector {
 
 	/**
 	 * This method is used by the {@link KnowledgeBase} to let its
-	 * {@link SmartConnectorImpl} (and via it other {@link KnowledgeBase}s) know
-	 * that it will ask certain types of questions for which it would like an
-	 * answer. This allows the {@link SmartConnectorImpl} to prepare.
+	 * {@link SmartConnector} (and via it other {@link KnowledgeBase}s) know that it
+	 * will ask certain types of questions for which it would like an answer. This
+	 * allows the {@link SmartConnector} to prepare.
 	 *
 	 * @param anAskKI The {@link AskKnowledgeInteraction} that the
 	 *                {@link KnowledgeBase} wants to register with this
-	 *                {@link SmartConnectorImpl}.
+	 *                {@link SmartConnector}.
 	 */
 	URI register(AskKnowledgeInteraction anAskKI);
 
 	/**
 	 * This method is used by the {@link KnowledgeBase} to let its
-	 * {@link SmartConnectorImpl} (and via it other {@link KnowledgeBase}s) know
-	 * that it no longer will ask certain types of questions. This allows the
-	 * {@link SmartConnectorImpl} to prepare.
+	 * {@link SmartConnector} (and via it other {@link KnowledgeBase}s) know that it
+	 * no longer will ask certain types of questions. This allows the
+	 * {@link SmartConnector} to prepare.
 	 *
 	 * @param anAskKI The {@link AskKnowledgeInteraction} that the
 	 *                {@link KnowledgeBase} wants to unregister from this
-	 *                {@link SmartConnectorImpl}.
+	 *                {@link SmartConnector}.
 	 */
 	void unregister(AskKnowledgeInteraction anAskKI);
 
 	/**
 	 * This method is used by the {@link KnowledgeBase} to let its
-	 * {@link SmartConnectorImpl} (and via it other {@link KnowledgeBase}s) know
-	 * that it can answer certain types of questions that other
-	 * {@link KnowledgeBase}s would like to
-	 * {@link #ask(AskKnowledgeInteraction, RecipientSelector, BindingSet)}. This
-	 * allows the {@link SmartConnectorImpl} to prepare.
+	 * {@link SmartConnector} (and via it other {@link KnowledgeBase}s) know that it
+	 * can answer certain types of questions that other {@link KnowledgeBase}s would
+	 * like to {@link #ask(AskKnowledgeInteraction, RecipientSelector, BindingSet)}.
+	 * This allows the {@link SmartConnector} to prepare.
 	 *
 	 * @param anAnswerKI     The {@link AskKnowledgeInteraction} that the
 	 *                       {@link KnowledgeBase} wants to register with this
-	 *                       {@link SmartConnectorImpl}.
+	 *                       {@link SmartConnector}.
 	 * @param aAnswerHandler The {@link AnswerHandler} that will process and answer
 	 *                       an incoming question from another
 	 *                       {@link KnowledgeBase}.
@@ -51,51 +50,50 @@ public interface SmartConnector {
 
 	/**
 	 * This method is used by the {@link KnowledgeBase} to let its
-	 * {@link SmartConnectorImpl} (and via it other {@link KnowledgeBase}s) know
-	 * that it no longer answers certain types of questions. This allows the
-	 * {@link SmartConnectorImpl} to prepare.
+	 * {@link SmartConnector} (and via it other {@link KnowledgeBase}s) know that it
+	 * no longer answers certain types of questions. This allows the
+	 * {@link SmartConnector} to prepare.
 	 *
-	 * @param anAnswerKI The {@link AswerKnowledgeInteraction} that the
+	 * @param anAnswerKI The {@link AnswerKnowledgeInteraction} that the
 	 *                   {@link KnowledgeBase} wants to unregister from this
-	 *                   {@link SmartConnectorImpl}.
+	 *                   {@link SmartConnector}.
 	 */
 	void unregister(AnswerKnowledgeInteraction anAnswerKI);
 
 	/**
 	 * This method is used by the {@link KnowledgeBase} to let its
-	 * {@link SmartConnectorImpl} (and via it other {@link KnowledgeBase}s) know
-	 * that it will post certain type of data in which other {@link KnowledgeBase}s
-	 * might want to react. This allows the {@link SmartConnectorImpl} to prepare.
+	 * {@link SmartConnector} (and via it other {@link KnowledgeBase}s) know that it
+	 * will post certain type of data in which other {@link KnowledgeBase}s might
+	 * want to react. This allows the {@link SmartConnector} to prepare.
 	 *
 	 * @param aPostKI The {@link PostKnowledgeInteraction} that the
 	 *                {@link KnowledgeBase} wants to register with this
-	 *                {@link SmartConnectorImpl}.
+	 *                {@link SmartConnector}.
 	 */
 	URI register(PostKnowledgeInteraction aPostKI);
 
 	/**
 	 * This method is used by the {@link KnowledgeBase} to let its
-	 * {@link SmartConnectorImpl} (and via it other {@link KnowledgeBase}s) know
-	 * that it will no longer post certain types of data. This allows the
-	 * {@link SmartConnectorImpl} to prepare.
+	 * {@link SmartConnector} (and via it other {@link KnowledgeBase}s) know that it
+	 * will no longer post certain types of data. This allows the
+	 * {@link SmartConnector} to prepare.
 	 *
 	 * @param aPostKI The {@link PostKnowledgeInteraction} that the
 	 *                {@link KnowledgeBase} wants to unregister from this
-	 *                {@link SmartConnectorImpl}.
+	 *                {@link SmartConnector}.
 	 */
 	void unregister(PostKnowledgeInteraction aPostKI);
 
 	/**
 	 * This method is used by the {@link KnowledgeBase} to let its
-	 * {@link SmartConnectorImpl} (and via it other {@link KnowledgeBase}s) know
-	 * that it wants to react to certain types of data that other
-	 * {@link KnowledgeBase}s will
-	 * {@link #post(PostKnowledgeInteraction, RecipientSelector, BindingSet)}. This
-	 * allows the {@link SmartConnectorImpl} to prepare.
+	 * {@link SmartConnector} (and via it other {@link KnowledgeBase}s) know that it
+	 * wants to react to certain types of data that other {@link KnowledgeBase}s
+	 * will {@link #post(PostKnowledgeInteraction, RecipientSelector, BindingSet)}.
+	 * This allows the {@link SmartConnector} to prepare.
 	 *
 	 * @param anReactKI     The {@link AskKnowledgeInteraction} that the
 	 *                      {@link KnowledgeBase} wants to register with this
-	 *                      {@link SmartConnectorImpl}.
+	 *                      {@link SmartConnector}.
 	 * @param aReactHandler The {@link AnswerHandler} that will process and answer
 	 *                      an incoming question from another {@link KnowledgeBase}.
 	 */
@@ -103,13 +101,13 @@ public interface SmartConnector {
 
 	/**
 	 * This method is used by the {@link KnowledgeBase} to let its
-	 * {@link SmartConnectorImpl} (and via it other {@link KnowledgeBase}s) know
-	 * that it no longer reacts to certain types of data. This allows the
-	 * {@link SmartConnectorImpl} to prepare.
+	 * {@link SmartConnector} (and via it other {@link KnowledgeBase}s) know that it
+	 * no longer reacts to certain types of data. This allows the
+	 * {@link SmartConnector} to prepare.
 	 *
 	 * @param anReactKI The {@link ReactKnowledgeInteraction} that the
 	 *                  {@link KnowledgeBase} wants to unregister from this
-	 *                  {@link SmartConnectorImpl}.
+	 *                  {@link SmartConnector}.
 	 */
 	void unregister(ReactKnowledgeInteraction anReactKI);
 
@@ -123,14 +121,14 @@ public interface SmartConnector {
 
 	/**
 	 * With this method a {@link KnowledgeBase} can ask a question to its
-	 * {@link SmartConnectorImpl}. The Smart Connector will first check which of all
-	 * the other {@link KnowledgeBase}s fit the {@link RecipientSelector} and
+	 * {@link SmartConnector}. The Smart Connector will first check which of all the
+	 * other {@link KnowledgeBase}s fit the {@link RecipientSelector} and
 	 * subsequently determine whether those that fit the selector have a compatible
 	 * or matching {@link AnswerKnowledgeInteraction}. The resulting other
 	 * {@link KnowledgeBase}s will have their matching
 	 * {@link AnswerKnowledgeInteraction}'s {@link AnswerHandler} triggered. If
 	 * there are multiple matching {@link KnowledgeBase}s this
-	 * {@link SmartConnectorImpl} will combine their results.
+	 * {@link SmartConnector} will combine their results.
 	 *
 	 * Using the {@link BindingSet} argument the caller can limit the question being
 	 * asked by providing one or more allowed values for the answers to certain
@@ -142,7 +140,7 @@ public interface SmartConnector {
 	 * might take a while.
 	 *
 	 * @param anAKI       The given {@link AskKnowledgeInteraction} should be
-	 *                    registered with the {@link SmartConnectorImpl} via the
+	 *                    registered with the {@link SmartConnector} via the
 	 *                    {@link #register(AskKnowledgeInteraction)} method.
 	 * @param aSelector   A selector that allows the {@link KnowledgeBase} to limit
 	 *                    the potential recipients that can answer the question. It
@@ -157,7 +155,7 @@ public interface SmartConnector {
 	 *                    {@link AskKnowledgeInteraction}. Cannot be null!
 	 * @return A {@link CompletableFuture} that will return a {@link AskResult} in
 	 *         the future when the question is successfully processed by the
-	 *         {@link SmartConnectorImpl}.
+	 *         {@link SmartConnector}.
 	 */
 	CompletableFuture<AskResult> ask(AskKnowledgeInteraction anAKI, RecipientSelector aSelector,
 			BindingSet aBindingSet);
@@ -168,10 +166,10 @@ public interface SmartConnector {
 	 * wildcard {@link RecipientSelector}. This means that all
 	 * {@link KnowledgeBase}s that have matching {@link KnowledgeInteraction}s are
 	 * allowed to answer the question being asked. This is the most interoperable
-	 * way in using the {@link SmartConnectorImpl}, because it allows any compatible
+	 * way in using the {@link SmartConnector}, because it allows any compatible
 	 * {@link KnowledgeBase} to join the data exchange.
 	 *
-	 * @see SmartConnectorImpl#ask(AskKnowledgeInteraction, RecipientSelector,
+	 * @see SmartConnector#ask(AskKnowledgeInteraction, RecipientSelector,
 	 *      BindingSet)
 	 * @see SmartConnector#planAsk(AskKnowledgeInteraction, RecipientSelector,
 	 *      BindingSet)
@@ -184,21 +182,20 @@ public interface SmartConnector {
 	 * 
 	 * @param aPKI
 	 * @param aSelector
-	 * @param someArguments
 	 * @return
 	 */
 	PostPlan planPost(PostKnowledgeInteraction aPKI, RecipientSelector aSelector);
 
 	/**
 	 * With this method a {@link KnowledgeBase} can post data to its
-	 * {@link SmartConnectorImpl}. The Smart Connector will first check which of all
-	 * the other {@link KnowledgeBase}s fit the {@link RecipientSelector} and
+	 * {@link SmartConnector}. The Smart Connector will first check which of all the
+	 * other {@link KnowledgeBase}s fit the {@link RecipientSelector} and
 	 * subsequently determine whether those that fit the selector have a compatible
 	 * or matching {@link ReactKnowledgeInteraction}. The resulting other
 	 * {@link KnowledgeBase}s will have their matching
 	 * {@link ReactKnowledgeInteraction}'s {@link ReactHandler} triggered. If there
-	 * are multiple matching {@link KnowledgeBase}s this {@link SmartConnectorImpl}
-	 * will allow all of them to react.
+	 * are multiple matching {@link KnowledgeBase}s this {@link SmartConnector} will
+	 * allow all of them to react.
 	 *
 	 * This type of interaction can be used to make interoperable publish/subscribe
 	 * like mechanisms where the post is the publish and the react (without a
@@ -224,7 +221,7 @@ public interface SmartConnector {
 	 * take a while.
 	 *
 	 * @param aPKI          The given {@link AskKnowledgeInteraction} should be
-	 *                      registered with the {@link SmartConnectorImpl} via the
+	 *                      registered with the {@link SmartConnector} via the
 	 *                      {@link #register(AskKnowledgeInteraction)} method.
 	 * @param aSelector     A selector that allows the {@link KnowledgeBase} to
 	 *                      limit the potential recipients that can answer the
@@ -240,7 +237,7 @@ public interface SmartConnector {
 	 *                      {@link AskKnowledgeInteraction}.
 	 * @return A {@link CompletableFuture} that will return a {@link PostResult} in
 	 *         the future when the post is successfully processed by the
-	 *         {@link SmartConnectorImpl}.
+	 *         {@link SmartConnector}.
 	 * 
 	 * @see SmartConnector#planPost(PostKnowledgeInteraction, RecipientSelector,
 	 *      BindingSet)
@@ -254,7 +251,7 @@ public interface SmartConnector {
 	 * wildcard {@link RecipientSelector}. This means that all
 	 * {@link KnowledgeBase}s that have matching {@link KnowledgeInteraction}s are
 	 * allowed to answer the question being asked. This is the most interoperable
-	 * way in using the {@link SmartConnectorImpl}, because it allows any compatible
+	 * way in using the {@link SmartConnector}, because it allows any compatible
 	 * {@link KnowledgeBase} to join the data exchange.
 	 *
 	 * @see #post(PostKnowledgeInteraction, RecipientSelector, BindingSet)
@@ -290,22 +287,22 @@ public interface SmartConnector {
 	boolean isReasonerEnabled();
 
 	/**
-	 * Stops the current {@link SmartConnectorImpl}. Note that this methods is
+	 * Stops the current {@link SmartConnector}. Note that this methods is
 	 * asynchronous and will call
-	 * {@link KnowledgeBase#smartConnectorStopped(SmartConnectorImpl)} when this
-	 * smart connector has successfully stopped.
+	 * {@link KnowledgeBase#smartConnectorStopped(SmartConnector)} when this smart
+	 * connector has successfully stopped.
 	 *
-	 * After it has stopped, the {@link SmartConnectorImpl} can no longer be used by
-	 * its {@link KnowledgeBase} to exchange data and the {@link KnowledgeBase}
-	 * itself is no longer available to other {@link KnowledgeBase} for
-	 * interoperable data exchange.
+	 * After it has stopped, the {@link SmartConnector} can no longer be used by its
+	 * {@link KnowledgeBase} to exchange data and the {@link KnowledgeBase} itself
+	 * is no longer available to other {@link KnowledgeBase} for interoperable data
+	 * exchange.
 	 *
 	 * Between calling this method and having the
-	 * {@link KnowledgeBase#smartConnectorStopped(SmartConnectorImpl)} method
-	 * called, its methods should not be called and the behaviour of the
-	 * {@link SmartConnectorImpl} is unpredictable.
+	 * {@link KnowledgeBase#smartConnectorStopped(SmartConnector)} method called,
+	 * its methods should not be called and the behaviour of the
+	 * {@link SmartConnector} is unpredictable.
 	 *
-	 * Note that a stopped {@link SmartConnectorImpl} can no longer be used.
+	 * Note that a stopped {@link SmartConnector} can no longer be used.
 	 */
 	void stop();
 

--- a/smart-connector/src/main/java/eu/knowledge/engine/smartconnector/impl/InteractionProcessor.java
+++ b/smart-connector/src/main/java/eu/knowledge/engine/smartconnector/impl/InteractionProcessor.java
@@ -32,7 +32,7 @@ import eu.knowledge.engine.smartconnector.messaging.ReactMessage;
  *
  * For this, it needs to know which knowledge interactions are offered by the
  * knowledge base that this smart connector is attached to. For this, it uses
- * {@link KnowledgeBaseStore}, and also {@link MyMetaKnowledgeBase} for the
+ * {@link KnowledgeBaseStore}, and also {@link MetaKnowledgeBase} for the
  * knowledge interactions about the metadata that all smart connectors
  * automatically offer.
  *
@@ -63,10 +63,6 @@ public interface InteractionProcessor {
 	 * @param aSelector   The {@link RecipientSelector} to limit the
 	 *                    OtherKnowledgeBases who's
 	 *                    {@link AnswerKnowledgeInteraction} will be called.
-	 * @param aBindingSet The {@link BindingSet} containing limitations on the
-	 *                    expected answers. The variable names in the bindings
-	 *                    should occur in the {@link GraphPattern} of the
-	 *                    {@link AskKnowledgeInteraction}.
 	 * @return A future to an {@link AskResult}. This means this method immediately
 	 *         returns and will continue processing the
 	 *         {@link AskKnowledgeInteraction} in the background. Once the
@@ -82,10 +78,6 @@ public interface InteractionProcessor {
 	 * @param aSelector   The {@link RecipientSelector} to limit the
 	 *                    OtherKnowledgeBases who's
 	 *                    {@link ReactKnowledgeInteraction} will be called.
-	 * @param aBindingSet The {@link BindingSet} containing limitations on the
-	 *                    expected answers. The variable names in the bindings
-	 *                    should occur in the {@link GraphPattern} of the
-	 *                    {@link PostKnowledgeInteraction}.
 	 * @return A future to an {@link AskResult}. This means this method immediately
 	 *         returns and will continue processing the
 	 *         {@link PostKnowledgeInteraction} in the background. Once the
@@ -97,10 +89,10 @@ public interface InteractionProcessor {
 	/**
 	 * Interprets the given {@link AskMessage} and returns an {@link AnswerMessage}
 	 * by delegating the {@link BindingSet} to the correct {@link AnswerHandler}, OR
-	 * to a handler in {@link MyMetaKnowledgeBase} if the incoming message asks for
+	 * to a handler in {@link MetaKnowledgeBase} if the incoming message asks for
 	 * metadata about this knowledge base.
 	 *
-	 * @param anAskMsg The {@link AskMessage} that requires an answer.
+	 * @param askMessage The {@link AskMessage} that requires an answer.
 	 * @return A future {@link AnswerMessage}.
 	 */
 	CompletableFuture<AnswerMessage> processAskFromMessageRouter(AskMessage askMessage);
@@ -111,7 +103,7 @@ public interface InteractionProcessor {
 	 * to a handler in {@link OtherKnowledgeBaseStore} if it concerns metadata about
 	 * other knowledge bases.
 	 *
-	 * @param aPostMsg The {@link PostMessage} that requires a reaction.
+	 * @param postMessage The {@link PostMessage} that requires a reaction.
 	 * @return A future {@link ReactMessage}.
 	 */
 	CompletableFuture<ReactMessage> processPostFromMessageRouter(PostMessage postMessage);

--- a/smart-connector/src/main/java/eu/knowledge/engine/smartconnector/impl/MessageRouter.java
+++ b/smart-connector/src/main/java/eu/knowledge/engine/smartconnector/impl/MessageRouter.java
@@ -19,8 +19,8 @@ import eu.knowledge.engine.smartconnector.messaging.ReactMessage;
  * reply has been received.</li>
  * <li>Incoming messages, for which this {@link SmartConnector} needs to create
  * a reply, are forwarded to the right internal component. For normal messages
- * this is the {@link ProactiveInteractionProcessor}, for meta data related
- * messages this is the {@link MyMetaKnowledgeBase}.
+ * this is the {@link InteractionProcessor}, for meta data related
+ * messages this is the {@link MetaKnowledgeBase}.
  * </ul>
  */
 public interface MessageRouter {
@@ -50,7 +50,7 @@ public interface MessageRouter {
 	CompletableFuture<ReactMessage> sendPostMessage(PostMessage postMessage) throws IOException;
 
 	/**
-	 * Register the {@link MyMetaKnowledgeBase} so it can receive incoming messages
+	 * Register the {@link MetaKnowledgeBase} so it can receive incoming messages
 	 * for which a reply needs to be created.
 	 *
 	 * @param metaKnowledgeBase

--- a/smart-connector/src/main/java/eu/knowledge/engine/smartconnector/impl/MetaKnowledgeBase.java
+++ b/smart-connector/src/main/java/eu/knowledge/engine/smartconnector/impl/MetaKnowledgeBase.java
@@ -9,7 +9,7 @@ import eu.knowledge.engine.smartconnector.api.PostResult;
  * This class is responsible for: - dereferencing knowledge base URIs into
  * {@link OtherKnowledgeBase} objects. - answering incoming meta ASK
  * interactions that ask for metaknowledge about this knowledge base. In short,
- * it is very similar to the {@InteractionProcessor} for the reactive
+ * it is very similar to the {@link InteractionProcessor} for the reactive
  * meta-knowledge messages, but for the proactive messages, it is also
  * responsible for parsing the knowledge base IDs into meta knowledge
  * interaction using a convention. This convention is also defined by the class

--- a/smart-connector/src/main/java/eu/knowledge/engine/smartconnector/impl/SmartConnectorImpl.java
+++ b/smart-connector/src/main/java/eu/knowledge/engine/smartconnector/impl/SmartConnectorImpl.java
@@ -169,7 +169,7 @@ public class SmartConnectorImpl implements RuntimeSmartConnector, LoggerProvider
 	 * that it no longer answers certain types of questions. This allows the
 	 * {@link SmartConnectorImpl} to prepare.
 	 *
-	 * @param anAnswerKI The {@link AswerKnowledgeInteraction} that the
+	 * @param anAnswerKI The {@link AnswerKnowledgeInteraction} that the
 	 *                   {@link KnowledgeBase} wants to unregister from this
 	 *                   {@link SmartConnectorImpl}.
 	 */

--- a/smart-connector/src/main/java/eu/knowledge/engine/smartconnector/util/KnowledgeBaseImpl.java
+++ b/smart-connector/src/main/java/eu/knowledge/engine/smartconnector/util/KnowledgeBaseImpl.java
@@ -138,7 +138,7 @@ public class KnowledgeBaseImpl implements KnowledgeBase {
 	 * connectors in the knowledge network and be able to wait for everyone to be up
 	 * to date.
 	 * 
-	 * @param aPhaser a concurrent object that allows multiple parties to wait for
+	 * @param aReadyPhaser a concurrent object that allows multiple parties to wait for
 	 *                each other to go through different phases.
 	 */
 	public void setPhaser(Phaser aReadyPhaser) {


### PR DESCRIPTION
Generating javadoc using the maven javadoc plugin still fails with errors due to a bug in the javadoc generator. You can disable this strict checking bug by configuring 'nolint' to 'none'.