### PR TITLE
The MetadataKB used the wrong reasoner level.

### DIFF
--- a/admin-ui/src/main/java/eu/knowledge/engine/admin/MetadataKB.java
+++ b/admin-ui/src/main/java/eu/knowledge/engine/admin/MetadataKB.java
@@ -21,6 +21,7 @@ import eu.knowledge.engine.smartconnector.api.AskKnowledgeInteraction;
 import eu.knowledge.engine.smartconnector.api.BindingSet;
 import eu.knowledge.engine.smartconnector.api.CommunicativeAct;
 import eu.knowledge.engine.smartconnector.api.GraphPattern;
+import eu.knowledge.engine.smartconnector.api.MatchStrategy;
 import eu.knowledge.engine.smartconnector.api.ReactExchangeInfo;
 import eu.knowledge.engine.smartconnector.api.ReactKnowledgeInteraction;
 import eu.knowledge.engine.smartconnector.api.Vocab;
@@ -73,7 +74,8 @@ public class MetadataKB extends KnowledgeBaseImpl {
 		this.metaGraphPattern = new GraphPattern(this.prefixes, META_GRAPH_PATTERN_STR);
 
 		// create the correct Knowledge Interactions
-		this.aKI = new AskKnowledgeInteraction(new CommunicativeAct(), this.metaGraphPattern, true);
+		this.aKI = new AskKnowledgeInteraction(new CommunicativeAct(), this.metaGraphPattern, null, false, true,
+				false, MatchStrategy.ENTRY_LEVEL);
 		this.rKINew = new ReactKnowledgeInteraction(
 				new CommunicativeAct(new HashSet<Resource>(Arrays.asList(Vocab.NEW_KNOWLEDGE_PURPOSE)),
 						new HashSet<Resource>(Arrays.asList(Vocab.INFORM_PURPOSE))),


### PR DESCRIPTION
This caused the KE to freeze during graph pattern matching, because a too high reasoner level combined with the large metadata graph pattern.