### PR TITLE
Improve error handling and remove meta KI names again.

### DIFF
--- a/smart-connector-api/src/main/java/eu/knowledge/engine/smartconnector/api/AnswerHandler.java
+++ b/smart-connector-api/src/main/java/eu/knowledge/engine/smartconnector/api/AnswerHandler.java
@@ -2,6 +2,8 @@ package eu.knowledge.engine.smartconnector.api;
 
 import java.util.concurrent.CompletableFuture;
 
+import org.slf4j.LoggerFactory;
+
 /**
  * An {@link AnswerHandler} provides a handler
  * {@code AnswerHandler#answer(AnswerKnowledgeInteraction, BindingSet)} method
@@ -36,6 +38,7 @@ public interface AnswerHandler {
 			BindingSet bs = this.answer(anAKI, anAnswerExchangeInfo);
 			future.complete(bs);
 		} catch (Exception e) {
+			LoggerFactory.getLogger(AnswerHandler.class).error("{}", e);
 			future.completeExceptionally(e);
 		}
 		return future;

--- a/smart-connector-api/src/main/java/eu/knowledge/engine/smartconnector/api/KnowledgeInteraction.java
+++ b/smart-connector-api/src/main/java/eu/knowledge/engine/smartconnector/api/KnowledgeInteraction.java
@@ -2,10 +2,9 @@ package eu.knowledge.engine.smartconnector.api;
 
 /**
  * A {@link KnowledgeInteraction} represents an agreement about the exchange of
- * knowledge between the {@link SmartConnector} and the
- * {@link KnowledgeBase}. It expresses the 'shape' of knowledge that a
- * {@link KnowledgeBase} asks from, or can provide to its
- * {@link SmartConnector}.
+ * knowledge between the {@link SmartConnector} and the {@link KnowledgeBase}.
+ * It expresses the 'shape' of knowledge that a {@link KnowledgeBase} asks from,
+ * or can provide to its {@link SmartConnector}.
  */
 public abstract class KnowledgeInteraction {
 
@@ -131,7 +130,8 @@ public abstract class KnowledgeInteraction {
 	private void validateName(String name) {
 		if (name != null && !name.matches("[a-zA-Z0-9-]*")) {
 			throw new IllegalArgumentException(
-					"Knowledge Interaction names can only contain alphanumeric characters and hyphens.");
+					"Knowledge Interaction names should only contain alphanumeric characters and hyphens and not '"
+							+ name + "'");
 		}
 	}
 }

--- a/smart-connector-api/src/main/java/eu/knowledge/engine/smartconnector/api/ReactHandler.java
+++ b/smart-connector-api/src/main/java/eu/knowledge/engine/smartconnector/api/ReactHandler.java
@@ -2,10 +2,13 @@ package eu.knowledge.engine.smartconnector.api;
 
 import java.util.concurrent.CompletableFuture;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * A {@link ReactHandler} provides a handler method
- * ({@link ReactHandler#react(ReactKnowledgeInteraction, ReactExchangeInfo)}) that
- * returns a {@link BindingSet} for the provided input. Unlike in the
+ * ({@link ReactHandler#react(ReactKnowledgeInteraction, ReactExchangeInfo)})
+ * that returns a {@link BindingSet} for the provided input. Unlike in the
  * {@link AnswerHandler}, which only has a single {@link GraphPattern}, the
  * {@link GraphPattern} of the result *can* be different from the argument's.
  */
@@ -36,7 +39,9 @@ public interface ReactHandler {
 			BindingSet bs = this.react(anRKI, aReactExchangeInfo);
 			future.complete(bs);
 		} catch (Exception e) {
+			LoggerFactory.getLogger(ReactHandler.class).error("{}", e);
 			future.completeExceptionally(e);
+
 		}
 		return future;
 	}

--- a/smart-connector/src/main/java/eu/knowledge/engine/smartconnector/impl/MetaKnowledgeBaseImpl.java
+++ b/smart-connector/src/main/java/eu/knowledge/engine/smartconnector/impl/MetaKnowledgeBaseImpl.java
@@ -102,25 +102,25 @@ public class MetaKnowledgeBaseImpl implements MetaKnowledgeBase, KnowledgeBaseSt
 		this.metaPostNewKI = new PostKnowledgeInteraction(
 				new CommunicativeAct(new HashSet<>(Arrays.asList(Vocab.INFORM_PURPOSE)),
 						new HashSet<>(Arrays.asList(Vocab.NEW_KNOWLEDGE_PURPOSE))),
-				this.metaGraphPattern, null, "post-new", true, true, MatchStrategy.ENTRY_LEVEL);
+				this.metaGraphPattern, null, null, true, true, MatchStrategy.ENTRY_LEVEL);
 		this.knowledgeBaseStore.register(this.metaPostNewKI, true);
 
 		this.metaPostChangedKI = new PostKnowledgeInteraction(
 				new CommunicativeAct(new HashSet<>(Arrays.asList(Vocab.INFORM_PURPOSE)),
 						new HashSet<>(Arrays.asList(Vocab.CHANGED_KNOWLEDGE_PURPOSE))),
-				this.metaGraphPattern, null, "post-changed", true, true, MatchStrategy.ENTRY_LEVEL);
+				this.metaGraphPattern, null, null, true, true, MatchStrategy.ENTRY_LEVEL);
 		this.knowledgeBaseStore.register(this.metaPostChangedKI, true);
 
 		this.metaPostRemovedKI = new PostKnowledgeInteraction(
 				new CommunicativeAct(new HashSet<>(Arrays.asList(Vocab.INFORM_PURPOSE)),
 						new HashSet<>(Arrays.asList(Vocab.REMOVED_KNOWLEDGE_PURPOSE))),
-				this.metaGraphPattern, null, "post-removed", true, true, MatchStrategy.ENTRY_LEVEL);
+				this.metaGraphPattern, null, null, true, true, MatchStrategy.ENTRY_LEVEL);
 		this.knowledgeBaseStore.register(this.metaPostRemovedKI, true);
 
 		this.metaReactNewKI = new ReactKnowledgeInteraction(
 				new CommunicativeAct(new HashSet<>(Arrays.asList(Vocab.NEW_KNOWLEDGE_PURPOSE)),
 						new HashSet<>(Arrays.asList(Vocab.INFORM_PURPOSE))),
-				this.metaGraphPattern, null, "react-new", true, true, MatchStrategy.ENTRY_LEVEL);
+				this.metaGraphPattern, null, null, true, true, MatchStrategy.ENTRY_LEVEL);
 		this.knowledgeBaseStore.register(this.metaReactNewKI, (aRKI, aReactExchangeInfo) -> {
 			var postingKi = aReactExchangeInfo.getPostingKnowledgeInteractionId();
 			var itShouldBeThis = this.knowledgeBaseStore.getMetaId(aReactExchangeInfo.getPostingKnowledgeBaseId(),
@@ -140,7 +140,7 @@ public class MetaKnowledgeBaseImpl implements MetaKnowledgeBase, KnowledgeBaseSt
 		this.metaReactChangedKI = new ReactKnowledgeInteraction(
 				new CommunicativeAct(new HashSet<>(Arrays.asList(Vocab.CHANGED_KNOWLEDGE_PURPOSE)),
 						new HashSet<>(Arrays.asList(Vocab.INFORM_PURPOSE))),
-				this.metaGraphPattern, null, "react-changed", true, true, MatchStrategy.ENTRY_LEVEL);
+				this.metaGraphPattern, null, null, true, true, MatchStrategy.ENTRY_LEVEL);
 		this.knowledgeBaseStore.register(this.metaReactChangedKI, (aRKI, aReactExchangeInfo) -> {
 			var postingKi = aReactExchangeInfo.getPostingKnowledgeInteractionId();
 			var itShouldBeThis = this.knowledgeBaseStore.getMetaId(aReactExchangeInfo.getPostingKnowledgeBaseId(),
@@ -160,7 +160,7 @@ public class MetaKnowledgeBaseImpl implements MetaKnowledgeBase, KnowledgeBaseSt
 		this.metaReactRemovedKI = new ReactKnowledgeInteraction(
 				new CommunicativeAct(new HashSet<>(Arrays.asList(Vocab.REMOVED_KNOWLEDGE_PURPOSE)),
 						new HashSet<>(Arrays.asList(Vocab.INFORM_PURPOSE))),
-				this.metaGraphPattern, null, "react-removed", true, true, MatchStrategy.ENTRY_LEVEL);
+				this.metaGraphPattern, null, null, true, true, MatchStrategy.ENTRY_LEVEL);
 		this.knowledgeBaseStore.register(this.metaReactRemovedKI, (aRKI, aReactExchangeInfo) -> {
 			var postingKi = aReactExchangeInfo.getPostingKnowledgeInteractionId();
 			var itShouldBeThis = this.knowledgeBaseStore.getMetaId(aReactExchangeInfo.getPostingKnowledgeBaseId(),


### PR DESCRIPTION
Done:
- the handler exceptions were only visible in the exchange info on the proactive side, but now they are also logged to the reactive side.
- the meta KI names are not used (their URIs are fixed by the KnowledgeBaseStoreImpl), so we removed them again.