### PR TITLE
Uses latest 3.11 alpine image previous image is not available any more

### DIFF
--- a/examples/rest-api/knowledge-bases/Dockerfile.sensor
+++ b/examples/rest-api/knowledge-bases/Dockerfile.sensor
@@ -1,4 +1,4 @@
-FROM python:3.11.1-alpine
+FROM python:3.11-alpine
 
 # Create and enable venv
 RUN python -m venv /opt/venv

--- a/examples/rest-api/knowledge-bases/Dockerfile.storage
+++ b/examples/rest-api/knowledge-bases/Dockerfile.storage
@@ -1,4 +1,4 @@
-FROM python:3.11.1-alpine
+FROM python:3.11-alpine
 
 # Create and enable venv
 RUN python -m venv /opt/venv

--- a/examples/rest-api/knowledge-bases/Dockerfile.ui
+++ b/examples/rest-api/knowledge-bases/Dockerfile.ui
@@ -1,4 +1,4 @@
-FROM python:3.11.1-alpine
+FROM python:3.11-alpine
 
 # Create and enable venv
 RUN python -m venv /opt/venv


### PR DESCRIPTION
The docker image `python:3.11.1-alpine` is not available any more so `docker compose up` this project will fail. The PR replaces the docker image with `python:3.11-alpine` which will pull the latest 3.11 patch.