### PR TITLE
Performance and logging improvements.

### DIFF
--- a/reasoner/src/main/java/eu/knowledge/engine/reasoner/api/TripleNode.java
+++ b/reasoner/src/main/java/eu/knowledge/engine/reasoner/api/TripleNode.java
@@ -18,10 +18,10 @@ public class TripleNode {
 
 	public TripleNode(TriplePattern aTriplePattern, Node aNode, int aNodeIdx) {
 		assert (0 <= aNodeIdx && aNodeIdx <= 2);
-		this.hashCodeValue = this.calcHashCode();
 		this.tp = aTriplePattern;
 		this.node = aNode;
 		this.nodeIdx = aNodeIdx;
+		this.hashCodeValue = this.calcHashCode();
 	}
 
 	public TripleNode(TriplePattern aTriplePattern, String aNode, int aNodeIdx) {

--- a/reasoner/src/main/java/eu/knowledge/engine/reasoner/api/TriplePattern.java
+++ b/reasoner/src/main/java/eu/knowledge/engine/reasoner/api/TriplePattern.java
@@ -64,7 +64,7 @@ public class TriplePattern {
 	 * @return
 	 */
 	public Map<TripleNode, TripleNode> findMatches(TriplePattern other) {
-		Map<TripleNode, TripleNode> substitutionMap = new HashMap<>();
+		Map<TripleNode, TripleNode> substitutionMap = new HashMap<>(3);
 
 		if (this.getSubject() instanceof Var || other.getSubject() instanceof Var) {
 			substitutionMap.put(new TripleNode(this, this.getSubject(), 0),

--- a/reasoner/src/main/java/eu/knowledge/engine/reasoner/api/TripleVarBindingSet.java
+++ b/reasoner/src/main/java/eu/knowledge/engine/reasoner/api/TripleVarBindingSet.java
@@ -156,6 +156,10 @@ public class TripleVarBindingSet {
 	 * @return
 	 */
 	public TripleVarBindingSet merge(TripleVarBindingSet aGraphBindingSet) {
+
+		LOG.trace("Merging {} bindings with our {} bindings.", aGraphBindingSet.getBindings().size(),
+				this.getBindings().size());
+
 		TripleVarBindingSet gbs = new TripleVarBindingSet(this.graphPattern);
 
 		if (this.bindings.isEmpty()) {
@@ -176,6 +180,9 @@ public class TripleVarBindingSet {
 				}
 			});
 		}
+
+		LOG.trace("Merged {} bindings with our {} bindings into {} bindings.", aGraphBindingSet.getBindings().size(),
+				this.getBindings().size(), gbs.getBindings().size());
 
 		return gbs;
 	}
@@ -251,6 +258,7 @@ public class TripleVarBindingSet {
 					newOne.add(toB);
 			}
 		}
+		LOG.trace("Translated binding set with '{}' bindings and '{}' matches.", this.bindings.size(), match.size());
 
 		return newOne;
 


### PR DESCRIPTION
Make sure trace log level allows us to notice long translating and merging times. The hashcode of the TripleNode was wrong (from the start) and this caused considerable performance bottleneck. It is now corrected.