### PR TITLE
With version 1.3.1 the admin-ui did no longer start.

### DIFF
--- a/admin-ui/pom.xml
+++ b/admin-ui/pom.xml
@@ -204,6 +204,11 @@
 							implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
 							<addHeader>false</addHeader>
 						</transformer>
+						<transformer
+							implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+							<resource>
+								META-INF/microprofile-config.properties</resource>
+						</transformer>
 					</transformers>
 					<filters>
 						<filter>


### PR DESCRIPTION
Updated the pom to prevent the default configuration of the smart-connector from being overwritten. Instead, all configuration files are now merged.

Also, make sure the admin-ui connections are determined based on the configured reasoner level.