### PR TITLE
Fix bug where domain knowledge was not correctly loaded.

### DIFF
--- a/smart-connector/src/main/java/eu/knowledge/engine/smartconnector/util/KnowledgeBaseImpl.java
+++ b/smart-connector/src/main/java/eu/knowledge/engine/smartconnector/util/KnowledgeBaseImpl.java
@@ -567,7 +567,8 @@ public class KnowledgeBaseImpl implements KnowledgeBase {
 		}
 		this.unregisteredReactKIs.clear();
 
-		this.getSC().setDomainKnowledge(this.domainKnowledge);
+		if (!this.domainKnowledge.isEmpty())
+			this.getSC().setDomainKnowledge(this.domainKnowledge);
 		this.getSC().setReasonerLevel(this.reasonerLevel);
 
 	}


### PR DESCRIPTION
If no domain knowledge was set in the KnowledgeBaseImpl class, it would still set the domain knowledge to the empty set although it might have been populated by the default domain knowledge configuration setting.