### PR TITLE
Make sure unit tests wait for SCs to have stopped before continuing.

### DIFF
--- a/admin-ui/src/main/java/eu/knowledge/engine/admin/MetadataKB.java
+++ b/admin-ui/src/main/java/eu/knowledge/engine/admin/MetadataKB.java
@@ -247,7 +247,11 @@ public class MetadataKB extends KnowledgeBaseImpl {
 	}
 
 	public void close() {
-		this.stop();
+		try {
+			this.stop().get();
+		} catch (InterruptedException | ExecutionException e) {
+			LOG.error("Exceptions should not occur when closing the MetadataKB.", e);
+		}
 	}
 
 	public Model getMetadata() {

--- a/admin-ui/src/test/java/eu/knowledge/engine/admin/api/TestApiRoutes.java
+++ b/admin-ui/src/test/java/eu/knowledge/engine/admin/api/TestApiRoutes.java
@@ -18,6 +18,7 @@ import java.net.http.HttpResponse;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 
 import org.apache.jena.shared.PrefixMapping;
 import org.apache.jena.sparql.graph.PrefixMappingMem;
@@ -309,7 +310,11 @@ public class TestApiRoutes {
 
 	public void stopKb(KnowledgeBaseImpl aKb) {
 		if (aKb != null) {
-			aKb.stop();
+			try {
+				aKb.stop().get();
+			} catch (InterruptedException | ExecutionException e) {
+				LOG.error("Stopping a KB should not throw an exception.", e);
+			}
 		}
 	}
 }

--- a/smart-connector/src/test/java/eu/knowledge/engine/smartconnector/api/TestAddingDeletingManySmartConnectors.java
+++ b/smart-connector/src/test/java/eu/knowledge/engine/smartconnector/api/TestAddingDeletingManySmartConnectors.java
@@ -1,106 +1,43 @@
 package eu.knowledge.engine.smartconnector.api;
 
-import java.net.URI;
-import java.net.URISyntaxException;
+import java.util.concurrent.ExecutionException;
 
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import eu.knowledge.engine.smartconnector.impl.SmartConnectorBuilder;
+import eu.knowledge.engine.smartconnector.util.KnowledgeBaseImpl;
+import eu.knowledge.engine.smartconnector.util.KnowledgeNetwork;
 
+@Tag("Long")
 public class TestAddingDeletingManySmartConnectors {
 
-	private static final int AMOUNT = 20;
+	private static final int AMOUNT = 25;
 	private Logger LOG = LoggerFactory.getLogger(TestAddingDeletingManySmartConnectors.class);
 
 	@Disabled
 	@Test
-	void test() throws InterruptedException {
+	void test() throws InterruptedException, ExecutionException {
 
-		KnowledgeBase[] kb = new KnowledgeBase[AMOUNT];
+		KnowledgeNetwork kn = new KnowledgeNetwork();
 
-		SmartConnector[] sc = new SmartConnector[AMOUNT];
-		LOG.info("Start creating SCs");
+		LOG.info("Creating SCs");
 		for (int i = 0; i < AMOUNT; i++) {
-
-			kb[i] = new MyKnowledgeBase("kb" + i);
-			sc[i] = SmartConnectorBuilder.newSmartConnector(kb[i]).create();
+			kn.addKB(new KnowledgeBaseImpl("kb" + i));
 		}
+		kn.sync();
 
-		Thread.sleep(20000);
+		LOG.info("Stopping SCs");
+		kn.stop().get();
 
-		LOG.info("Start stopping SCs");
+		LOG.info("Creating SCs again");
 		for (int i = 0; i < AMOUNT; i++) {
-			sc[i].stop();
+			kn.addKB(new KnowledgeBaseImpl("kb" + i));
 		}
-
-		Thread.sleep(5000);
-
-		LOG.info("Start creating SCs again");
-		sc = new SmartConnector[AMOUNT];
-		for (int i = 0; i < AMOUNT; i++) {
-
-			kb[i] = new MyKnowledgeBase("kb" + i);
-			sc[i] = SmartConnectorBuilder.newSmartConnector(kb[i]).create();
-		}
-
+		kn.sync();
+		LOG.info("Stopping SCs again");
+		kn.stop().get();
 	}
-
-	private static class MyKnowledgeBase implements KnowledgeBase {
-
-		private String name;
-
-		public MyKnowledgeBase(String name) {
-			this.name = name;
-		}
-
-		@Override
-		public URI getKnowledgeBaseId() {
-			try {
-				return new URI("http://www.example.org/" + name);
-			} catch (URISyntaxException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-				return null;
-			}
-		}
-
-		@Override
-		public String getKnowledgeBaseName() {
-			return name;
-		}
-
-		@Override
-		public String getKnowledgeBaseDescription() {
-			return this.name;
-		}
-
-		@Override
-		public void smartConnectorReady(SmartConnector aSC) {
-			// TODO Auto-generated method stub
-
-		}
-
-		@Override
-		public void smartConnectorConnectionLost(SmartConnector aSC) {
-			// TODO Auto-generated method stub
-
-		}
-
-		@Override
-		public void smartConnectorConnectionRestored(SmartConnector aSC) {
-			// TODO Auto-generated method stub
-
-		}
-
-		@Override
-		public void smartConnectorStopped(SmartConnector aSC) {
-			// TODO Auto-generated method stub
-
-		}
-
-	}
-
 }

--- a/smart-connector/src/test/java/eu/knowledge/engine/smartconnector/api/TestAskAnswerRealistic.java
+++ b/smart-connector/src/test/java/eu/knowledge/engine/smartconnector/api/TestAskAnswerRealistic.java
@@ -546,64 +546,64 @@ public class TestAskAnswerRealistic {
 	}
 
 	@AfterAll
-	public static void cleanup() {
+	public static void cleanup() throws InterruptedException, ExecutionException {
 		LOG.info("Clean up: {}", TestAskAnswerRealistic.class.getSimpleName());
 		if (kb1 != null) {
-			kb1.stop();
+			kb1.stop().get();
 		} else {
 			fail("KB1 should not be null!");
 		}
 
 		if (kb2 != null) {
-			kb2.stop();
+			kb2.stop().get();
 		} else {
 			fail("KB2 should not be null!");
 		}
 
 		if (kb3 != null) {
-			kb3.stop();
+			kb3.stop().get();
 		} else {
 			fail("KB3 should not be null!");
 		}
 
 		if (kb4 != null) {
-			kb4.stop();
+			kb4.stop().get();
 		} else {
 			fail("KB4 should not be null!");
 		}
 
 		if (kb5 != null) {
-			kb5.stop();
+			kb5.stop().get();
 		} else {
 			fail("KB5 should not be null");
 		}
 
 		if (kb6 != null) {
-			kb6.stop();
+			kb6.stop().get();
 		} else {
 			fail("KB6 should not be null");
 		}
 
 		if (kb7 != null) {
-			kb7.stop();
+			kb7.stop().get();
 		} else {
 			fail("KB7 should not be null");
 		}
 
 		if (kb8 != null) {
-			kb8.stop();
+			kb8.stop().get();
 		} else {
 			fail("KB8 should not be null");
 		}
 
 		if (kb9 != null) {
-			kb9.stop();
+			kb9.stop().get();
 		} else {
 			fail("KB9 should not be null");
 		}
 
 		if (kb10 != null) {
-			kb10.stop();
+			kb10.stop().get();
 		} else {
 			fail("KB10 should not be null");
 		}

--- a/smart-connector/src/test/java/eu/knowledge/engine/smartconnector/api/TestRegisterKnowledgeInteraction.java
+++ b/smart-connector/src/test/java/eu/knowledge/engine/smartconnector/api/TestRegisterKnowledgeInteraction.java
@@ -3,6 +3,7 @@ package eu.knowledge.engine.smartconnector.api;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.URI;
+import java.util.concurrent.ExecutionException;
 
 import org.junit.jupiter.api.Test;
 
@@ -10,7 +11,7 @@ import eu.knowledge.engine.smartconnector.impl.SmartConnectorBuilder;
 
 public class TestRegisterKnowledgeInteraction {
 	@Test
-	public void testRegisterKnowledgeInteractionWithSameName() {
+	public void testRegisterKnowledgeInteractionWithSameName() throws InterruptedException, ExecutionException {
 		var sc1 = SmartConnectorBuilder.newSmartConnector(new KnowledgeBase() {
 
 			@Override
@@ -55,7 +56,7 @@ public class TestRegisterKnowledgeInteraction {
 					false));
 		});
 
-		sc1.stop();
+		sc1.stop().get();
 	}
 
 }

--- a/smart-connector/src/test/java/eu/knowledge/engine/smartconnector/api/TestSmartConnectorStop.java
+++ b/smart-connector/src/test/java/eu/knowledge/engine/smartconnector/api/TestSmartConnectorStop.java
@@ -3,6 +3,7 @@ package eu.knowledge.engine.smartconnector.api;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
@@ -20,7 +21,7 @@ public class TestSmartConnectorStop {
 	private static AtomicBoolean scStoppedCalled = new AtomicBoolean(false);
 
 	@Test
-	public void test() throws InterruptedException {
+	public void test() throws InterruptedException, ExecutionException {
 
 		sc1 = SmartConnectorBuilder.newSmartConnector(new MyKnowledgeBase("kb1")).create();
 		sc2 = SmartConnectorBuilder.newSmartConnector(new MyKnowledgeBase("kb2")).create();
@@ -42,7 +43,7 @@ public class TestSmartConnectorStop {
 
 		Thread.sleep(500);
 
-		sc2.stop();
+		sc2.stop().get();
 	}
 
 	class MyKnowledgeBase implements KnowledgeBase {

--- a/smart-connector/src/test/java/eu/knowledge/engine/smartconnector/api/Thermostat.java
+++ b/smart-connector/src/test/java/eu/knowledge/engine/smartconnector/api/Thermostat.java
@@ -3,6 +3,7 @@ package eu.knowledge.engine.smartconnector.api;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Iterator;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -28,7 +29,7 @@ public class Thermostat {
 
 	ExecutorService es = Executors.newFixedThreadPool(4);
 
-	public static void main(String[] args) throws InterruptedException {
+	public static void main(String[] args) throws InterruptedException, ExecutionException {
 
 		Thermostat t = new Thermostat();
 
@@ -36,7 +37,7 @@ public class Thermostat {
 
 	}
 
-	public void start() throws InterruptedException {
+	public void start() throws InterruptedException, ExecutionException {
 		PrefixMappingMem prefixes = new PrefixMappingMem();
 		prefixes.setNsPrefixes(PrefixMapping.Standard);
 		prefixes.setNsPrefix("sosa", "http://www.w3.org/ns/sosa/");
@@ -173,9 +174,9 @@ public class Thermostat {
 		es.awaitTermination(100, TimeUnit.SECONDS);
 		LOG.info("Shutting down now.");
 		es.shutdownNow();
-		this.sensor.stop();
-		this.thermostat.stop();
-		this.heating.stop();
+		this.sensor.stop().get();
+		this.thermostat.stop().get();
+		this.heating.stop().get();
 
 	}
 

--- a/smart-connector/src/test/java/eu/knowledge/engine/smartconnector/impl/AnomalyDetectionTest.java
+++ b/smart-connector/src/test/java/eu/knowledge/engine/smartconnector/impl/AnomalyDetectionTest.java
@@ -121,8 +121,8 @@ class AnomalyDetectionTest {
 	}
 
 	@AfterAll
-	public static void close() {
-		kn.stop();
+	public static void close() throws InterruptedException, ExecutionException {
+		kn.stop().get();
 	}
 
 }

--- a/smart-connector/src/test/java/eu/knowledge/engine/smartconnector/misc/SmartConnectorRegistrationStressTest.java
+++ b/smart-connector/src/test/java/eu/knowledge/engine/smartconnector/misc/SmartConnectorRegistrationStressTest.java
@@ -107,7 +107,7 @@ public class SmartConnectorRegistrationStressTest {
 		LOG.info("Registration took {} milliseconds.", duration.toMillis());
 		assertTrue(duration.toSeconds() < TEST_FAIL_THRESHOLD_SECONDS);
 
-		sc.stop();
+		sc.stop().get();
 	}
 
 	@AfterAll


### PR DESCRIPTION
Otherwise the previous unit test might interfere with the next one, for example because a KB with the same name is being started, but the previous one was not fully stopped yet.